### PR TITLE
Changed/Fixed test_post_details(_v3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Visual Studio
+.vs/

--- a/src/jodel_api/jodel_api.py
+++ b/src/jodel_api/jodel_api.py
@@ -24,8 +24,8 @@ class JodelAccount:
 
     api_url = "https://api.go-tellm.com/api{}"
     client_id = '81e8a76e-1e02-4d17-9ba0-8a7020261b26'
-    secret = 'GnAXvETHFDbDfhngjDYEkszdqZowDpWsWuCectMJ'.encode('ascii')
-    version = '4.49.0'
+    secret = 'SUJlYgihNxTmcfdrEcjROozfNemiqJSjYpoJJMUC'.encode('ascii')
+    version = '4.55.1'
     secret_legacy = 'hyTBJcvtpDLSgGUWjybbYUNKSSoVvMcfdjtjiQvf'.encode('ascii')
     version_legacy = '4.47.0'
 

--- a/test/test_jodel_api.py
+++ b/test/test_jodel_api.py
@@ -166,11 +166,12 @@ class TestUnverifiedAccount:
 
     def test_post_details_v3(self):
         r = self.j.get_post_details_v3(self.pid3)
+        assert r[0] == 200
         replies = len(r[1]["replies"])
         while(r[1]["remaining"] > 0):
             r = self.j.get_post_details_v3(self.pid3, r[1]["next"])
+            assert r[0] == 200
             replies += len(r[1]["replies"])
-        assert r[0] == 200
         assert replies == r[1]["details"]["child_count"]
         
     def test_share_url(self):

--- a/test/test_jodel_api.py
+++ b/test/test_jodel_api.py
@@ -36,6 +36,7 @@ class TestUnverifiedAccount:
         self.pid = r[1]['posts'][0]['post_id']
         self.pid1 = r[1]['posts'][0]['post_id']
         self.pid2 = r[1]['posts'][1]['post_id']
+        self.pid3 = r[1]['posts'][5]['post_id']
         assert self.j.follow_channel(test_channel)[0] == 204
 
         assert self.j.get_account_data()['is_legacy'] == False
@@ -160,14 +161,14 @@ class TestUnverifiedAccount:
         assert self.j.get_notifications()[0] == 200
 
     def test_post_details(self):
-        r = self.j.get_post_details(self.pid)
+        r = self.j.get_post_details(self.pid3)
         assert r[0] == 200
 
     def test_post_details_v3(self):
-        r = self.j.get_post_details_v3(self.pid)
+        r = self.j.get_post_details_v3(self.pid3)
         replies = len(r[1]["replies"])
         while(r[1]["remaining"] > 0):
-            r = self.j.get_post_details_v3(self.pid, r[1]["next"])
+            r = self.j.get_post_details_v3(self.pid3, r[1]["next"])
             replies += len(r[1]["replies"])
         assert r[0] == 200
         assert replies == r[1]["details"]["child_count"]

--- a/test/test_jodel_api.py
+++ b/test/test_jodel_api.py
@@ -162,10 +162,15 @@ class TestUnverifiedAccount:
     def test_post_details(self):
         r = self.j.get_post_details(self.pid)
         assert r[0] == 200
-        assert len(r[1]["children"]) == r[1]["child_count"]
 
     def test_post_details_v3(self):
-        assert self.j.get_post_details_v3(self.pid)[0] == 200
+        r = self.j.get_post_details_v3(self.pid)
+        replies = len(r[1]["replies"])
+        while(r[1]["remaining"] > 0):
+            r = self.j.get_post_details_v3(self.pid, r[1]["next"])
+            replies += len(r[1]["replies"])
+        assert r[0] == 200
+        assert replies == r[1]["details"]["child_count"]
         
     def test_share_url(self):
         assert self.j.get_share_url(self.pid)[0] == 200


### PR DESCRIPTION
As mentioned in https://github.com/nborrmann/jodel_api/pull/41 "test_post_details" doesn't work anymore.

I removed the failing part and recreated the tested functionality (check if the actual replies equal the number in the "child_count" variable) in test_post_details_v3. Sometimes this still fails, I think that happens when someone just commented. That's why I changed it to don't check the most discussed jodel.

I think the old test doesn't work anymore because if there are too many replies they don't get returned with the v2 method. 
-> Tested it with a 10 reply post and it worked, children array was filled
-> Tested it with a > 40 reply post and it didn't work, children array was empty


I've also added the hmac key change in this pull request because otherwise the tests fail anyway.